### PR TITLE
URL Cleanup

### DIFF
--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/pom.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 <project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<groupId>com.vmware.vfra</groupId>
 	<artifactId>vfra-batch</artifactId>
@@ -39,7 +39,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/pom.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 <project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<parent>
 		<groupId>com.vmware.vfra</groupId>
@@ -51,7 +51,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/resources/META-INF/spring/batch/jobs/jobs-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/resources/META-INF/spring/batch/jobs/jobs-context.xml
@@ -4,11 +4,11 @@
 	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
 
 	<!-- spring.profiles.active not being recognized when vfra-batch-core context loaded -->

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/resources/META-INF/spring/batch/override/override-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/resources/META-INF/spring/batch/override/override-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
 
 	<!-- <import

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/resources/META-INF/spring/batch/servlet/override/service-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/resources/META-INF/spring/batch/servlet/override/service-context.xml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<import
 		resource="classpath:com/vmware/vfra/batch/CopyOrders-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/webapp/WEB-INF/web.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-admin/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
 			http://java.sun.com/xml/ns/j2ee
-			http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
+			https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
 
 	<context-param>
 		<param-name>contextConfigLocation</param-name>

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/pom.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -192,7 +192,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -200,7 +200,7 @@
 		<repository>
 			<id>repository.springframework.maven.release</id>
 			<name>Spring Framework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 		</repository>
 	</repositories>
 

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/CopyOrders-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/CopyOrders-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:task="http://www.springframework.org/schema/task"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/task  http://www.springframework.org/schema/task/spring-task.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/task  https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/SpringBatchInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/JdbcInfrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/JdbcInfrastructure-context.xml
@@ -4,11 +4,11 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:jee="http://www.springframework.org/schema/jee"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/jee https://www.springframework.org/schema/jee/spring-jee.xsd">
 
 
 	<bean id="reportingTxManager" lazy-init="true"

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/SpringBatchInfrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/SpringBatchInfrastructure-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/JdbcInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/web/controllers.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/web/controllers.xml
@@ -5,10 +5,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<beans:import resource="classpath:/com/vmware/vfra/batch/CopyOrders-context.xml" />
 

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/web/root-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/web/root-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 	
 	<!-- Root Context: defines shared resources visible to all other web components -->
 		

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/web/servlet-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/com/vmware/vfra/batch/web/servlet-context.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xsi:schemaLocation="
-        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+        http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<!-- DispatcherServlet Context: defines this servlet's request-processing infrastructure -->
 	

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/commandline/CommandLine-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/main/resources/commandline/CommandLine-context.xml
@@ -6,10 +6,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<beans:import resource="classpath:/com/vmware/vfra/batch/CopyOrders-context.xml" />
 

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/FailedStepTest-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/FailedStepTest-context.xml
@@ -3,9 +3,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/inttest/TestSpringBatchInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/OrderWriterTest-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/OrderWriterTest-context.xml
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/inttest/TestSpringBatchInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/PartitionStepTest-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/PartitionStepTest-context.xml
@@ -3,9 +3,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/inttest/TestSpringBatchInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/SuccessfulStepTest-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/SuccessfulStepTest-context.xml
@@ -3,9 +3,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/inttest/TestSpringBatchInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestDbInfrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestDbInfrastructure-context.xml
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<!-- To change between H2 and Postgres for integration tests: 1. uncomment 
 		one of these context files 2. update src/test/resources/vfra-batch.properties 

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestH2Infrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestH2Infrastructure-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<beans profile="dev">
 		<jdbc:initialize-database data-source="jobDataSource">

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestPostgresInfrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestPostgresInfrastructure-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!-- if running this for first time drop will fail, so you'll have to comment 
 		out the drop script. Probably a good precaution in case you're pointing to 

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestSpringBatchInfrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/TestSpringBatchInfrastructure-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/SpringBatchInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/WorkerControllerTest-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-core/src/test/resources/com/vmware/vfra/batch/inttest/WorkerControllerTest-context.xml
@@ -3,9 +3,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<import
 		resource="classpath:/com/vmware/vfra/batch/inttest/TestSpringBatchInfrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/pom.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 	<modelVersion>4.0.0</modelVersion>
 
@@ -274,7 +274,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -282,15 +282,15 @@
 		<repository>
 			<id>repository.springframework.maven.release</id>
 			<name>Spring Framework Maven Release Repository</name>
-			<url>http://repo.springsource.org/libs-release</url>
+			<url>https://repo.springsource.org/libs-release</url>
 		</repository>
 		<repository>
 			<id>repository.springframework.maven.snapshot</id>
 			<name>Spring Framework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 		</repository>
 
-		<!-- <repository> <id>QUERYDSL</id> <url>http://source.mysema.com/maven2/releases</url> 
+		<!-- <repository> <id>QUERYDSL</id> <url>https://source.mysema.com/maven2/releases</url> 
 			<layout>default</layout> </repository> -->
 	</repositories>
 

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/DataAccessInfrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/DataAccessInfrastructure-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:jpa="http://www.springframework.org/schema/data/jpa" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/data/jpa https://www.springframework.org/schema/data/jpa/spring-jpa.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
 	<jpa:repositories base-package="com.vmware.vfra.batch.report"
 		repository-impl-postfix="CustomImpl" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/META-INF/persistence.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/META-INF/persistence.xml
@@ -3,7 +3,7 @@
 <persistence
     xmlns="http://java.sun.com/xml/ns/persistence"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
     version="1.0">
     <persistence-unit name="vfra.batch.report" transaction-type="RESOURCE_LOCAL">   
     </persistence-unit>

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/SpringInfrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/SpringInfrastructure-context.xml
@@ -3,8 +3,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:property-placeholder location="classpath:vfra-batch-report.properties" />
 

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/web/controllers.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/web/controllers.xml
@@ -6,10 +6,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<!-- <beans:import resource="classpath:com/vmware/vfra/batch/report/SpringInfrastructure-context.xml" />-->
 	

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/web/root-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/web/root-context.xml
@@ -6,10 +6,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<beans:import resource="classpath:com/vmware/vfra/batch/report/SpringInfrastructure-context.xml" />
 	

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/web/servlet-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/resources/com/vmware/vfra/batch/report/web/servlet-context.xml
@@ -5,8 +5,8 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"	
 	xsi:schemaLocation="
-        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+        http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<!-- DispatcherServlet Context: defines this servlet's request-processing infrastructure -->
 	

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/webapp/WEB-INF/web.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<!-- The definition of the Root Spring Container shared by all Servlets 
 		and Filters -->

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/test/resources/com/vmware/vfra/batch/report/inttest/QueryDslTest-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/test/resources/com/vmware/vfra/batch/report/inttest/QueryDslTest-context.xml
@@ -4,9 +4,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<import
 		resource="classpath:com/vmware/vfra/batch/report/inttest/TestH2Infrastructure-context.xml" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/test/resources/com/vmware/vfra/batch/report/inttest/TestH2Infrastructure-context.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/test/resources/com/vmware/vfra/batch/report/inttest/TestH2Infrastructure-context.xml
@@ -3,10 +3,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 	
 	<jdbc:initialize-database data-source="dataSource">
 		<jdbc:script location="classpath:scripts/app-schema-drop-h2.sql" />

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-worker/pom.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-worker/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 	<modelVersion>4.0.0</modelVersion>
 	<parent>

--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-worker/src/main/webapp/WEB-INF/web.xml
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-worker/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<!-- The definition of the Root Spring Container shared by all Servlets 
 		and Filters -->

--- a/Topic-4-Development-Env-Setup/vfabricra-dev-setup/antlibs/ant-expect/pom.xml
+++ b/Topic-4-Development-Env-Setup/vfabricra-dev-setup/antlibs/ant-expect/pom.xml
@@ -1,7 +1,7 @@
 <!-- Portions Copyright (c) 2013 VMware, Inc. All rights reserved. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.vmware.vfabric.dev</groupId>
 	<artifactId>ant-expect</artifactId>

--- a/Topic-4-Development-Env-Setup/vfabricra-dev-setup/pom.xml
+++ b/Topic-4-Development-Env-Setup/vfabricra-dev-setup/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 <!-- Copyright (c) 2013 VMware, Inc. All rights reserved. -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.vmware.vfabric.gts</groupId>
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <version>0.0.1-SNAPSHOT</version>
   <name>VMware vFRA Project Environment Builder</name>
-  <url>http://www.vmware.com/vfabric</url>
+  <url>https://www.vmware.com/vfabric</url>
   <dependencies> 
     <dependency>
     	<groupId>net.sourceforge.expectj</groupId>

--- a/Topic-4-Development-Env-Setup/vfabricra-dev-setup/sqlfire/build.xml
+++ b/Topic-4-Development-Env-Setup/vfabricra-dev-setup/sqlfire/build.xml
@@ -187,7 +187,7 @@
 	</target>
 
 	<target name="fetch-deps">
-		<echo>**** Please download vFabric SQLFire from http://www.vmware.com/products/application-platform/vfabric-sqlfire/overview.html and place it in your repository (Currently set to ${vfra.repo})</echo>
+		<echo>**** Please download vFabric SQLFire from https://www.vmware.com/products/application-platform/vfabric-sqlfire/overview.html and place it in your repository (Currently set to ${vfra.repo})</echo>
 	</target>
 	
 	<target name="clean-processes" depends="init-props" description="Forcibly clean up running processes so that clean target works regardless of state. " >


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://source.mysema.com/maven2/releases (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://source.mysema.com/maven2/releases ([https](https://source.mysema.com/maven2/releases) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org with 2 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 6 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.springframework.org/schema/aop/spring-aop.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop.xsd ([https](https://www.springframework.org/schema/aop/spring-aop.xsd) result 200).
* http://www.springframework.org/schema/batch/spring-batch-2.1.xsd with 7 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch-2.1.xsd ([https](https://www.springframework.org/schema/batch/spring-batch-2.1.xsd) result 200).
* http://www.springframework.org/schema/batch/spring-batch.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch.xsd ([https](https://www.springframework.org/schema/batch/spring-batch.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 14 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 7 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/data/jpa/spring-jpa.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/jpa/spring-jpa.xsd ([https](https://www.springframework.org/schema/data/jpa/spring-jpa.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc.xsd) result 200).
* http://www.springframework.org/schema/jee/spring-jee.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jee/spring-jee.xsd ([https](https://www.springframework.org/schema/jee/spring-jee.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://repo.springsource.org/libs-release with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/snapshot with 2 occurrences migrated to:  
  https://repo.springsource.org/snapshot ([https](https://repo.springsource.org/snapshot) result 301).
* http://www.vmware.com/products/application-platform/vfabric-sqlfire/overview.html with 1 occurrences migrated to:  
  https://www.vmware.com/products/application-platform/vfabric-sqlfire/overview.html ([https](https://www.vmware.com/products/application-platform/vfabric-sqlfire/overview.html) result 301).
* http://www.vmware.com/vfabric with 1 occurrences migrated to:  
  https://www.vmware.com/vfabric ([https](https://www.vmware.com/vfabric) result 301).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).
* http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).
* http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd ([https](https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd) result 302).
* http://maven.springframework.org/milestone with 4 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 6 occurrences
* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://java.sun.com/xml/ns/javaee with 4 occurrences
* http://java.sun.com/xml/ns/persistence with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 14 occurrences
* http://www.springframework.org/schema/aop with 4 occurrences
* http://www.springframework.org/schema/batch with 31 occurrences
* http://www.springframework.org/schema/beans with 60 occurrences
* http://www.springframework.org/schema/context with 26 occurrences
* http://www.springframework.org/schema/data/jpa with 2 occurrences
* http://www.springframework.org/schema/jdbc with 25 occurrences
* http://www.springframework.org/schema/jee with 2 occurrences
* http://www.springframework.org/schema/mvc with 13 occurrences
* http://www.springframework.org/schema/p with 2 occurrences
* http://www.springframework.org/schema/task with 2 occurrences
* http://www.springframework.org/schema/tx with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 37 occurrences