### PR TITLE
URL Cleanup

### DIFF
--- a/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/webapp/resources/js/excanvas.js
+++ b/Topic-11-Data-Modernization-Data-Movement/vfra-batch/vfra-batch-report/src/main/webapp/resources/js/excanvas.js
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Topic-4-Development-Env-Setup/vfabricra-dev-setup/antlibs/ant-expect/src/main/java/com/vmware/vfra/dev/ExpectTask.java
+++ b/Topic-4-Development-Env-Setup/vfabricra-dev-setup/antlibs/ant-expect/src/main/java/com/vmware/vfra/dev/ExpectTask.java
@@ -8,7 +8,7 @@
  *  (the "License"); you may not use this file except in compliance with
  *  the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/open_source_license_vFRA10.txt
+++ b/open_source_license_vFRA10.txt
@@ -381,7 +381,7 @@ The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with
 the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -415,7 +415,7 @@ ant.jar
 /*
  *                                 Apache License
  *                           Version 2.0, January 2004
- *                        http://www.apache.org/licenses/
+ *                        https://www.apache.org/licenses/
  *
  *   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
  *
@@ -607,7 +607,7 @@ ant.jar
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
@@ -694,7 +694,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -713,7 +713,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -1515,7 +1515,7 @@ Or alternatively the license texts may be found here:
     http://scripts.sil.org/OFL
     http://en.wikipedia.org/wiki/BSD_licenses
     http://www.gzip.org/zlib/zlib_license.html
-    http://www.apache.org/licenses/LICENSE-2.0.html
+    https://www.apache.org/licenses/LICENSE-2.0.html
 
 
 =============== APPENDIX. Standard License Files ============== 
@@ -1527,7 +1527,7 @@ Or alternatively the license texts may be found here:
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 6 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).